### PR TITLE
Add null check protection

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ AutoDetectDecoderStream.prototype._consumeBufferForDetection = function (chunk, 
             // Try to detect encoding
             this._detectedEncoding = jschardet.detect(this._detectionBuffer).encoding;
 
-            if (this._detectedEncoding === 'ascii') {
+            if (!this._detectedEncoding || this._detectedEncoding === 'ascii') {
                 //noinspection ExceptionCaughtLocallyJS
                 throw new Error('Not enough data, recognized as ASCII. We probably need to use the fallback.');
             }


### PR DESCRIPTION
Hello!

I wanted to use your lib, but there is a small bug.
If you put a high minimum confidence, you might get a null from chardet and that would not fallback to the default encoding.
So this fixes the issue.