### PR TITLE
Prevent error when piping from empty stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# lock
+package-lock.json
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -38,16 +38,16 @@ util.inherits(AutoDetectDecoderStream, Transform);
  * @param {function} done
  */
 AutoDetectDecoderStream.prototype._consumeBufferForDetection = function (chunk, done) {
+    if (!this._detectionBuffer) {
+
+        // Initialize buffer on first invocation
+        this._detectionBuffer = Buffer.alloc(0);
+    }
 
     if (chunk) {
 
         // Concatenate buffers until we get the minimum size we want
-        if (this._detectionBuffer) {
-            this._detectionBuffer = Buffer.concat([this._detectionBuffer, chunk]);
-        } else {
-            this._detectionBuffer = chunk;
-        }
-
+        this._detectionBuffer = Buffer.concat([this._detectionBuffer, chunk]);
     }
 
     // Do we have enough buffer?

--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
   "dependencies": {
     "jschardet": "1.*",
     "iconv-lite": "0.*"
+  },
+  "devDependencies": {
+    "jest": "23.*",
+    "stream-buffers": "3.*"
   }
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,97 @@
+const fs = require('fs');
+
+const iconv = require('iconv-lite');
+const streamBuffers = require('stream-buffers');
+
+const AutoDetectDecoderStream = require('../');
+
+describe('Autodetect Detector Stream', () => {
+  let stream;
+  let result;
+
+  beforeAll(() => {
+    iconv.getCodec('ascii'); // Force lazy loading of encoding before tests, otherwise it fails 
+  });
+
+  beforeEach(() => {
+    stream = new streamBuffers.ReadableStreamBuffer();
+    result = '';
+  });
+
+  test('Basic ASCII encoding', (done) => {
+    const buffer = new Buffer([0x54, 0x65, 0x73, 0x74]);
+    stream.pipe(new AutoDetectDecoderStream({ defaultEncoding: 'ascii' }))
+      .on('data', (data) => {
+        result += data;
+      })
+      .on('end', () => {
+        expect(result).toEqual('Test');
+        done();
+      });
+    stream.put(buffer);
+    stream.stop();
+  });
+
+  test('No detection fallback to default encoding', (done) => {
+    const buffer = new Buffer([0xBF, 0x54, 0x65, 0x73, 0x74]);
+    stream.pipe(new AutoDetectDecoderStream({ defaultEncoding: 'utf8', minConfidence: 1 }))
+      .on('data', (data) => {
+        result += data;
+      })
+      .on('end', () => {
+        expect(result).toEqual('�Test');
+        done();
+      });
+    stream.put(buffer);
+    stream.stop();
+  });
+
+  test('Empty stream returns empty data', (done) => {
+    const buffer = new Buffer([]);
+    stream.pipe(new AutoDetectDecoderStream({ defaultEncoding: 'ascii' }))
+      .on('data', (data) => {
+        result += data;
+      })
+      .on('end', () => {
+        expect(result).toEqual('');
+        done();
+      });
+    stream.put(buffer);
+    stream.stop();
+  });
+
+  test('Unknown encoding emits error', (done) => {
+    const buffer = new Buffer([]);
+    stream.pipe(new AutoDetectDecoderStream({ defaultEncoding: 'cp99999' }))
+      .on('error', (err) => {
+        expect(err).not.toBeNull();
+        done();
+      });
+    stream.put(buffer);
+    stream.stop();
+  });
+
+  test('Collect callback', (done) => {
+    const buffer = new Buffer([0x54, 0x65, 0x73, 0x74]);
+    stream.pipe(new AutoDetectDecoderStream({ defaultEncoding: 'ascii' }))
+      .collect((err, body) => {
+        expect(err).toBeNull();
+        expect(body).toEqual('Test');
+        done();
+      });
+    stream.put(buffer);
+    stream.stop();
+  });
+
+  test('Collect callback with error', (done) => {
+    const buffer = new Buffer([]);
+    stream.pipe(new AutoDetectDecoderStream({ defaultEncoding: 'cp99999' }))
+      .collect((err, body) => {
+        expect(err).not.toBeNull();
+        expect(body).toBeUndefined();
+        done();
+      });
+    stream.put(buffer);
+    stream.stop();
+  });
+});


### PR DESCRIPTION
If you pipe an empty stream, the current lib will throw.
This prevents that.
Since this is breaking change of the interface response, I suggest bumping the minor.
I also added some basic tests to help maintain.