### PR TITLE
Adding engines to package.json for webpack-babel-env-deps support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   ],
   "author": "Daniel Cohen Gindi <danielgindi@gmail.com> (https://github.com/danielgindi)",
   "license": "MIT",
+  "engines": {
+    "node": ">= 6"
+  },
   "bugs": {
     "url": "https://github.com/danielgindi/node-autodetect-decoder-stream/issues"
   },


### PR DESCRIPTION
This addition allows webpack-babel-env-deps to be used without special rules, when transpiling to ES5.